### PR TITLE
added credentialsRefresher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage
 *.code-workspace
 /testkit/CAs
 /testkit/CustomCAs
+/.vs

--- a/packages/bolt-connection/src/connection/connection-channel.js
+++ b/packages/bolt-connection/src/connection/connection-channel.js
@@ -175,11 +175,11 @@ export default class ChannelConnection extends Connection {
     const self = this
     // credentialsRefresher is function to refresh credentials
     if (authToken && authToken.credentialsRefresher) {
-        var maybePromise = authToken.credentialsRefresher(authToken)
-        return Promise.resolve(maybePromise).then(function(creds) {
-            authToken.credentials = creds
-            return self._initialize(userAgent, authToken);
-        })
+      const maybePromise = authToken.credentialsRefresher()
+      return Promise.resolve(maybePromise).then(function (creds) {
+        authToken.credentials = creds
+        return self._initialize(userAgent, authToken)
+      })
     }
 
     return self._initialize(userAgent, authToken)

--- a/packages/bolt-connection/src/connection/connection-channel.js
+++ b/packages/bolt-connection/src/connection/connection-channel.js
@@ -172,7 +172,17 @@ export default class ChannelConnection extends Connection {
    * @return {Promise<Connection>} promise resolved with the current connection if connection is successful. Rejected promise otherwise.
    */
   connect (userAgent, authToken) {
-    return this._initialize(userAgent, authToken)
+    const self = this
+    // credentialsRefresher is function to refresh credentials
+    if (authToken && authToken.credentialsRefresher) {
+        var maybePromise = authToken.credentialsRefresher(authToken)
+        return Promise.resolve(maybePromise).then(function(creds) {
+            authToken.credentials = creds
+            return self._initialize(userAgent, authToken);
+        })
+    }
+
+    return self._initialize(userAgent, authToken)
   }
 
   /**

--- a/packages/bolt-connection/src/packstream/packstream-v1.js
+++ b/packages/bolt-connection/src/packstream/packstream-v1.js
@@ -119,14 +119,14 @@ class Packer {
 
         let count = 0
         for (let i = 0; i < keys.length; i++) {
-          if (x[keys[i]] !== undefined) {
+          if (x[keys[i]] !== undefined && keys[i] !== "credentialsRefresher") {
             count++
           }
         }
         this.packMapHeader(count)
         for (let i = 0; i < keys.length; i++) {
           const key = keys[i]
-          if (x[key] !== undefined) {
+          if (x[key] !== undefined && key !== "credentialsRefresher") {
             this.packString(key)
             this.packable(x[key], dehydrateStruct)()
           }

--- a/packages/bolt-connection/test/packstream/packstream-v1.test.js
+++ b/packages/bolt-connection/test/packstream/packstream-v1.test.js
@@ -182,6 +182,13 @@ describe('#unit PackStreamV1', () => {
     expect(unpacked[0]).toBe(list[0])
     expect(unpacked[1]).toBe(list[1])
   })
+
+  it('should pack object with credentialsRefresher function', () => {
+    const obj = { foo: 'bar', credentialsRefresher: () => 'top-secret-password' }
+    const unpacked = packAndUnpack(obj)
+    expect(unpacked.foo).toBe(obj.foo)
+    expect(unpacked.credentialsRefresher).toBe(undefined)
+  })
 })
 
 function packAndUnpack (

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -47,6 +47,7 @@ export interface AuthToken {
   credentials: string
   realm?: string
   parameters?: Parameters
+  credentialsRefresher?: () => string | Promise<string>
 }
 export interface Config {
   encrypted?: boolean | EncryptionLevel

--- a/packages/neo4j-driver-deno/lib/core/types.ts
+++ b/packages/neo4j-driver-deno/lib/core/types.ts
@@ -47,6 +47,7 @@ export interface AuthToken {
   credentials: string
   realm?: string
   parameters?: Parameters
+  credentialsRefresher?: () => string | Promise<string>
 }
 export interface Config {
   encrypted?: boolean | EncryptionLevel


### PR DESCRIPTION
Add the ability to Refresh Auth Token Credentials

Currently when credentials expire, driver will continue trying to connect with the outdated credentials. There is no ability to update or refresh login credentials (See #993).

This PR introduces the ability to pass an optional `credentialsRefresher` function to an authToken object which will change credentials as they become obsolete.

There are no breaking changes introduced in this PR.

There is a test which validates these modifications by using a simple `credentialsRefresher` not breaks serialization.

Also tested with AWS Neptune, new credentials were correctly used to create a new connection.

Intended use
```
async function createDriver() {
  let authToken = { scheme: "basic", realm: "realm", principal: "username", credentialsRefresher: signedHeader };

  return neo4j.driver(url, authToken, {
      encrypted: "ENCRYPTION_ON",
      trust: "TRUST_SYSTEM_CA_SIGNED_CERTIFICATES",
      maxConnectionPoolSize: 2,
      maxConnectionLifetime: 2000
    }
  );
}
```